### PR TITLE
WSFM: Optimize writing large areas of 0xFF bytes.

### DIFF
--- a/src/cartridge/ws_cartridge.cpp
+++ b/src/cartridge/ws_cartridge.cpp
@@ -453,7 +453,7 @@ void ws_cartridge::restore_cartridge_game_data(std::istream& fin, int slot, task
   // Begin writing data block-by-block
   try
   {
-    // Open connection to NGP chip
+    // Open connection to WS chip
     m_linkmasta->open();
     
     while (bytes_written < bytes_total && (controller == nullptr || !controller->is_task_cancelled()))

--- a/src/cartridge/ws_rom_chip.cpp
+++ b/src/cartridge/ws_rom_chip.cpp
@@ -147,12 +147,18 @@ protect_t ws_rom_chip::get_block_protection(address_t sector_address)
 
 void ws_rom_chip::program_word(address_t address, word_t data)
 {
+  // Writing a 0xFF value to NOR flash is equivalent to a no-operation.
+  if (data == 0xFF)
+  {
+	return;
+  }
+  
   if (is_erasing())
   {
     // We can only reset when we're not erasing
     throw std::runtime_error("Chip still erasing");
   }
-  
+
   // Reset if in autoselect mode
   if (current_mode() != BYPASS && current_mode() != READ)
   {


### PR DESCRIPTION
Based on datasheets, an erased block of NOR flash will always be full of '1' bits (0xFF), and it is impossible to set them back from '0' to '1' without erasing. This means that attempting to write any 0xFF bytes is an effective no-operation.

To allow homebrew making use of this quirk to load faster, I've added a small optimization which skips writing larger areas of packets in burst mode in this situation.